### PR TITLE
Hold/unhold bug fix

### DIFF
--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -1641,7 +1641,7 @@ class RTCSession extends EventManager {
   Future<RTCSessionDescription> _createLocalDescription(
       String type, Map<String, dynamic>? constraints) async {
     logger.debug('createLocalDescription()');
-    _iceGatheringState = RTCIceGatheringState.RTCIceGatheringStateNew;
+    // _iceGatheringState = RTCIceGatheringState.RTCIceGatheringStateNew;
     Completer<RTCSessionDescription> completer =
         Completer<RTCSessionDescription>();
 


### PR DESCRIPTION
RTCIceGatheringStateNew was an issue that cause hold/unhold bug (internal WebRTC status not ready), because this state didn't update correctly (in time) before _isReadyToReOffer check